### PR TITLE
Fix typo on parameter scheme for relation hasmetadata

### DIFF
--- a/datacite-to-dcat-ap.xsl
+++ b/datacite-to-dcat-ap.xsl
@@ -2105,7 +2105,7 @@
       </xsl:if>
       <xsl:if test="$relation = 'hasmetadata'">
         <rdf:type rdf:resource="{$dcat}CatalogRecord"/>
-	<xsl:if test="$cheme != '' or $schemeURI != ''">
+        <xsl:if test="$scheme != '' or $schemeURI != ''">
           <xsl:choose>
             <xsl:when test="$scheme != '' and $schemeURI != ''">
               <dct:conformsTo>


### PR DESCRIPTION
Fixes #10
I also replace the `tab` character by 8 spaces (since it was the only occurrence of a `tab` character in the whole file).